### PR TITLE
Add overloading of ClientBuilder in order to instantiate a Client mock.

### DIFF
--- a/src/ElasticsearchMock/ClientBuilder.php
+++ b/src/ElasticsearchMock/ClientBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace M6Web\Component\ElasticsearchMock;
+
+/**
+ * Class ClientBuilder
+ *
+ * @package M6Web\Component\ElasticsearchMock
+ */
+class ClientBuilder extends \Elasticsearch\ClientBuilder
+{
+    /**
+     * @param array $config
+     * @param bool  $quiet
+     *
+     * @inheritdoc
+     *
+     * @return mixed
+     */
+    public static function fromConfig($config, $quiet = false)
+    {
+        $builder = static::create();
+
+        foreach ($config as $key => $value) {
+            $method = "set$key";
+            if (method_exists($builder, $method)) {
+                $builder->$method($value);
+                unset($config[$key]);
+            }
+        }
+
+        if ($quiet === false && count($config) > 0) {
+            $unknown = implode(array_keys($config));
+            throw new \RuntimeException("Unknown parameters provided: $unknown");
+        }
+
+        return $builder->build();
+    }
+
+    protected function instantiate(\Elasticsearch\Transport $transport, callable $endpoint)
+    {
+        return new Client($transport, $endpoint);
+    }
+}

--- a/tests/units/ClientBuilder.php
+++ b/tests/units/ClientBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace M6Web\Component\ElasticsearchMock\tests\units;
+
+use mageekguy\atoum\test;
+use M6Web\Component\ElasticsearchMock;
+
+/**
+ * Elasticsearch mock test
+ */
+class ClientBuilder extends test
+{
+    public function testCreate()
+    {
+        $this
+            ->object(ElasticsearchMock\ClientBuilder::create())
+                ->isInstanceOf(ElasticsearchMock\ClientBuilder::class)
+            ;
+    }
+
+    public function testFromConfig()
+    {
+        $this
+            ->object(ElasticsearchMock\ClientBuilder::fromConfig([]))
+                ->isInstanceOf(ElasticsearchMock\Client::class)
+            ;
+    }
+}


### PR DESCRIPTION
# Why
In ES client 2.0, it's not possible anymore to overide the client class name. We have to overload the ClientBuilder.

# How
Add a ClientBuilder where `instantiate` return a `Client` from `ElasticsearchMock`. Overload the `fromConfig` function because the parent use `new self`;