### PR TITLE
Upgrade to es 50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr-4": { "M6Web\\Component\\": "src/" }
     },
     "require": {
-        "php"                         : ">=5.6.6",
+        "php"                         : ">=7.0",
         "elasticsearch/elasticsearch" : "^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "psr-4": { "M6Web\\Component\\": "src/" }
     },
     "require": {
-        "php"                         : ">=5.4.0",
-        "elasticsearch/elasticsearch" : "^2.0"
+        "php"                         : ">=5.6.6",
+        "elasticsearch/elasticsearch" : "^5.0"
     },
     "require-dev": {
         "atoum/atoum"                    : "^2.8",

--- a/src/ElasticsearchMock/Client.php
+++ b/src/ElasticsearchMock/Client.php
@@ -26,12 +26,13 @@ class Client extends \Elasticsearch\Client
     protected $calls = [];
 
     /**
-     * Client constructor.
+     * Client constructor
      *
-     * @param Transport $transport
-     * @param callable  $endpoint
+     * @param Transport           $transport
+     * @param callable            $endpoint
+     * @param AbstractNamespace[] $registeredNamespaces
      */
-    public function __construct(Transport $transport = null, callable $endpoint = null)
+    public function __construct(Transport $transport = null, callable $endpoint = null, array $registeredNamespaces = [])
     {
         // Do nothing.
     }
@@ -151,16 +152,6 @@ class Client extends \Elasticsearch\Client
      *
      * @return array
      */
-    public function termvector($params = [])
-    {
-        return $this->getMethodResult(__FUNCTION__, func_get_args());
-    }
-
-    /**
-     * @param array $params
-     *
-     * @return array
-     */
     public function mtermvectors($params = [])
     {
         return $this->getMethodResult(__FUNCTION__, func_get_args());
@@ -172,16 +163,6 @@ class Client extends \Elasticsearch\Client
      * @return array
      */
     public function exists($params)
-    {
-        return $this->getMethodResult(__FUNCTION__, func_get_args());
-    }
-
-    /**
-     * @param array $params
-     *
-     * @return array
-     */
-    public function mlt($params)
     {
         return $this->getMethodResult(__FUNCTION__, func_get_args());
     }
@@ -262,16 +243,6 @@ class Client extends \Elasticsearch\Client
      * @return array
      */
     public function search($params = [])
-    {
-        return $this->getMethodResult(__FUNCTION__, func_get_args());
-    }
-
-    /**
-     * @param array $params
-     *
-     * @return array
-     */
-    public function searchExists($params = [])
     {
         return $this->getMethodResult(__FUNCTION__, func_get_args());
     }
@@ -479,6 +450,16 @@ class Client extends \Elasticsearch\Client
     }
 
     /**
+     * Operate on the Ingest namespace of commands
+     *
+     * @return IngestNamespace
+     */
+    public function ingest()
+    {
+        return $this->getMethodResult(__FUNCTION__, func_get_args());
+    }
+
+    /**
      * Operate on the Cat namespace of commands
      *
      * @return CatNamespace
@@ -486,6 +467,20 @@ class Client extends \Elasticsearch\Client
     public function tasks()
     {
        return $this->getMethodResult(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * Catchall for registered namespaces
+     *
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return Object
+     * @throws BadMethodCallException if the namespace cannot be found
+     */
+    public function __call($name, $arguments)
+    {
+        return $this->getMethodResult(__FUNCTION__, func_get_args());
     }
 
     /**

--- a/src/ElasticsearchMock/ClientBuilder.php
+++ b/src/ElasticsearchMock/ClientBuilder.php
@@ -37,8 +37,8 @@ class ClientBuilder extends \Elasticsearch\ClientBuilder
         return $builder->build();
     }
 
-    protected function instantiate(\Elasticsearch\Transport $transport, callable $endpoint)
+    protected function instantiate(\Elasticsearch\Transport $transport, callable $endpoint, array $registeredNamespaces)
     {
-        return new Client($transport, $endpoint);
+        return new Client($transport, $endpoint, $registeredNamespaces);
     }
 }


### PR DESCRIPTION
# Why
A new major version of the elasticsearch client is out.

# How
Update composer  and mocks.
Drop test support of 5.6 (security fixes only : http://php.net/supported-versions.php, and travis does'nt support 5.6.6).