### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__.'/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.0
+  - 7.1
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "elasticsearch/elasticsearch" : "^5.0"
     },
     "require-dev": {
-        "atoum/atoum"                    : "^2.8",
+        "atoum/atoum"                    : "^2.8|^3.0",
         "m6web/coke"                     : "~1.2",
         "m6web/symfony2-coding-standard" : "~1.1"
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-require_once __DIR__.'/../vendor/autoload.php';
-require_once __DIR__.'/../vendor/atoum/atoum/scripts/runner.php';


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.